### PR TITLE
Add Cursor Cloud dev environment setup (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,10 @@
 
 ## Cursor Cloud specific instructions
 
-This is **Kibana 8.0.0** (a large Bazel/Yarn monorepo). It is a browser-based
-analytics/search UI for Elasticsearch, so running the app end-to-end requires an
-Elasticsearch instance in addition to the Kibana dev server.
+This is **Kibana 8.0.0** (a large Bazel/Yarn monorepo). For typical Cursor Cloud
+agent work, **checking out the code and bootstrapping deps is enough** — do
+**not** start Elasticsearch or the Kibana dev server unless the task explicitly
+asks you to run the application end-to-end.
 
 Standard setup/run/test commands are documented in `README.md`,
 `CONTRIBUTING.md`, `dev_docs/getting_started/setting_up_a_development_env.mdx`,
@@ -31,31 +32,23 @@ are captured below.
   `BUILD_TS_REFS_CACHE_ENABLE=false` to skip the cache lookup (TS refs are still
   built locally). The startup update script already does this.
 
-### Elasticsearch (required to run Kibana)
-- Start it with: `yarn es snapshot --license trial` (downloads/extracts a
-  snapshot into `.es/8.0.0`, then runs it). Dev credentials are
-  `elastic` / `changeme`; it listens on **http://localhost:9200** (plain HTTP,
-  security enabled).
-- **Critical caveat:** the snapshot's bundled JDK crashes on startup in this
-  container with a cgroup v2 NPE
-  (`CgroupV2Subsystem.getInstance ... anyController is null`) while parsing JVM
-  options. Work around it by exporting `JDK_JAVA_OPTIONS="-XX:-UseContainerSupport"`
-  in the shell that launches ES (kbn-es forwards `process.env` to the ES child,
-  so this reaches the JVM option parser). Without it, ES exits with code 1 before
-  it starts.
-
-### Kibana dev server
-- Start it (in a separate shell, after ES is up) with: `yarn start`.
-- The first start compiles ~117 optimizer bundles (a few minutes) before the app
-  is available; wait for `Kibana is now available`.
-- In dev mode Kibana serves under a **random base path** printed in the logs
-  (e.g. `http://localhost:5601/wuh`). Pass `--no-base-path` to `yarn start` to
-  pin it to `http://localhost:5601/`. Log in through the form with
-  `elastic` / `changeme` (browser sessions use the login form, not HTTP basic
-  auth).
-
 ### Lint / test
 - Full-repo lint and test suites are enormous; scope them to a path/package.
   - ESLint: `node scripts/eslint <path>`  (style: `node scripts/stylelint`)
   - Jest unit: `node scripts/jest <path>` (e.g. `node scripts/jest packages/kbn-std`)
-  - Jest integration / FTR: `node scripts/jest_integration`, `node scripts/functional_tests`.
+  - Jest integration / FTR: `node scripts/jest_integration`, `node scripts/functional_tests`
+    (these may need Elasticsearch; only run when the task requires them).
+
+### Running Kibana / Elasticsearch (only when explicitly requested)
+Do not start these for ordinary code/lint/unit-test tasks.
+
+- Elasticsearch: `yarn es snapshot --license trial` → `http://localhost:9200`,
+  credentials `elastic` / `changeme`.
+  - **Caveat:** the snapshot's bundled JDK crashes on startup in this container
+    with a cgroup v2 NPE (`CgroupV2Subsystem.getInstance ... anyController is
+    null`). Export `JDK_JAVA_OPTIONS="-XX:-UseContainerSupport"` in the shell
+    that launches ES (kbn-es forwards `process.env` to the ES child).
+- Kibana: `yarn start` (after ES is up). First start compiles ~117 optimizer
+  bundles. Dev mode serves under a **random base path** (e.g.
+  `http://localhost:5601/wuh`); pass `--no-base-path` to pin to `/`. Log in via
+  the form with `elastic` / `changeme`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is **Kibana 8.0.0** (a large Bazel/Yarn monorepo). It is a browser-based
+analytics/search UI for Elasticsearch, so running the app end-to-end requires an
+Elasticsearch instance in addition to the Kibana dev server.
+
+Standard setup/run/test commands are documented in `README.md`,
+`CONTRIBUTING.md`, `dev_docs/getting_started/setting_up_a_development_env.mdx`,
+and `package.json` `scripts`. Only the non-obvious, environment-specific caveats
+are captured below.
+
+### Node / Yarn
+- Kibana requires the exact Node version in `.node-version` (**16.11.1**). The VM
+  ships a newer default Node (v22) and the exec harness puts its own `node` early
+  on `PATH`, so plain `node`/`yarn` may resolve to the wrong version.
+- Node 16.11.1 (with a matching global `yarn`) is installed via `nvm` and both
+  binaries live in `~/.nvm/versions/node/v16.11.1/bin`. `~/.bashrc` prepends this
+  to `PATH`, so **interactive/login shells (including tmux) get Node 16
+  automatically**. If you spawn a shell that does not source `~/.bashrc`, prepend
+  it yourself: `export PATH="$HOME/.nvm/versions/node/v16.11.1/bin:$PATH"`.
+
+### Bootstrap (dependency install) — handled by the startup update script
+- `yarn kbn bootstrap` installs deps and builds packages via the vendored Bazel
+  (bazelisk is fetched automatically; no separate Bazel install needed).
+- **Caveat:** the final `build_ts_refs` step tries `git fetch
+  https://github.com/elastic/kibana.git master` to pull a TS-refs build cache.
+  Upstream's default branch is now `main`, so that fetch fails with
+  `couldn't find remote ref master` and aborts bootstrap. Run bootstrap with
+  `BUILD_TS_REFS_CACHE_ENABLE=false` to skip the cache lookup (TS refs are still
+  built locally). The startup update script already does this.
+
+### Elasticsearch (required to run Kibana)
+- Start it with: `yarn es snapshot --license trial` (downloads/extracts a
+  snapshot into `.es/8.0.0`, then runs it). Dev credentials are
+  `elastic` / `changeme`; it listens on **http://localhost:9200** (plain HTTP,
+  security enabled).
+- **Critical caveat:** the snapshot's bundled JDK crashes on startup in this
+  container with a cgroup v2 NPE
+  (`CgroupV2Subsystem.getInstance ... anyController is null`) while parsing JVM
+  options. Work around it by exporting `JDK_JAVA_OPTIONS="-XX:-UseContainerSupport"`
+  in the shell that launches ES (kbn-es forwards `process.env` to the ES child,
+  so this reaches the JVM option parser). Without it, ES exits with code 1 before
+  it starts.
+
+### Kibana dev server
+- Start it (in a separate shell, after ES is up) with: `yarn start`.
+- The first start compiles ~117 optimizer bundles (a few minutes) before the app
+  is available; wait for `Kibana is now available`.
+- In dev mode Kibana serves under a **random base path** printed in the logs
+  (e.g. `http://localhost:5601/wuh`). Pass `--no-base-path` to `yarn start` to
+  pin it to `http://localhost:5601/`. Log in through the form with
+  `elastic` / `changeme` (browser sessions use the login form, not HTTP basic
+  auth).
+
+### Lint / test
+- Full-repo lint and test suites are enormous; scope them to a path/package.
+  - ESLint: `node scripts/eslint <path>`  (style: `node scripts/stylelint`)
+  - Jest unit: `node scripts/jest <path>` (e.g. `node scripts/jest packages/kbn-std`)
+  - Jest integration / FTR: `node scripts/jest_integration`, `node scripts/functional_tests`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Kibana 8.0.0 development environment for Cursor Cloud agents and documents the non-obvious, environment-specific caveats needed to bootstrap, lint, and unit-test the codebase.

**Scope:** checkout + dependency bootstrap is enough for typical agent work. Running Elasticsearch / Kibana is **optional** and only needed when a task explicitly asks for the live app.

This PR only adds `AGENTS.md`; all installed dependencies/build artifacts are gitignored. The dependency-refresh step is captured separately in the startup update script.

## What was set up
- **Node 16.11.1** (from `.node-version`) + matching global `yarn` via `nvm` (the VM default is Node v22). `~/.bashrc` prepends the Node 16 bin dir so interactive/tmux shells get the right version.
- **`yarn kbn bootstrap`** (vendored Bazel) to install deps and build packages.

## Key caveats documented in AGENTS.md
- Do **not** start ES/Kibana unless the task explicitly requires running the app.
- `yarn kbn bootstrap`'s final `build_ts_refs` step does `git fetch ... master` for a TS-refs cache, which fails because upstream's default branch is now `main`. Setting `BUILD_TS_REFS_CACHE_ENABLE=false` skips the cache lookup (refs still build locally). This is baked into the update script.
- If/when ES is needed: the snapshot's bundled JDK crashes with a cgroup v2 NPE in this container; export `JDK_JAVA_OPTIONS="-XX:-UseContainerSupport"` when launching ES.

## Verification
- **Lint:** `node scripts/eslint packages/kbn-std/src/index.ts` → clean (exit 0).
- **Test:** `node scripts/jest packages/kbn-std` → 13 suites / 98 tests passed.
- **Bootstrap:** `BUILD_TS_REFS_CACHE_ENABLE=false yarn kbn bootstrap` → success (idempotent ~7s warm re-run).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2302bff0-efff-4f01-ab1d-dc6667aa7582?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2302bff0-efff-4f01-ab1d-dc6667aa7582&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

